### PR TITLE
support space-delimited rel-types and unquoted rel-types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,12 +12,22 @@
   return function (linksHeader) {
     var result = {};
     var entries = linksHeader.split(',');
+    // compile regular expressions ahead of time for efficiency
+    var relsRegExp = /\brel="?([^"]+)"?\s*;?/;
+    var keysRegExp = /(\b[0-9a-z\.-]+\b)/g;
+    var sourceRegExp = /^<(.*)>/;
 
     for (var i = 0; i < entries.length; i++) {
       var entry = entries[i].trim();
-      var key = /rel="(.*)"/.exec(entry)[1];
-      var source = /^<(.*)>/.exec(entry)[1];
-      result[key] = source;
+      var rels = relsRegExp.exec(entry);
+      if (rels) {
+        var keys = rels[1].match(keysRegExp);
+        var source = sourceRegExp.exec(entry)[1];
+        var k, kLength = keys.length;
+        for (k = 0; k < kLength; k += 1) {
+          result[keys[k]] = source
+        }
+      }
     }
 
     return result;

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,7 +1,9 @@
 var parseLinks = require('../lib');
 var fixture = '</api/users?page=0&per_page=2>; rel="first", ' +
               '</api/users?page=1&per_page=2>; rel="next", ' +
-              '</api/users?page=3&per_page=2>; rel="last"';
+              '</api/users?page=3&per_page=2>; rel="last", ' +
+              '</api/users/123>;rel=self, ' +
+              '</api/users/12345>;rel="related alternate"';
 
 describe('parse-links', function () {
   it('parse the links!', function () {
@@ -9,5 +11,8 @@ describe('parse-links', function () {
     parsed.first.should.eql('/api/users?page=0&per_page=2');
     parsed.next.should.eql('/api/users?page=1&per_page=2');
     parsed.last.should.eql('/api/users?page=3&per_page=2');
+    parsed.self.should.eql('/api/users/123');
+    parsed.alternate.should.eql('/api/users/12345');
+    parsed.related.should.eql('/api/users/12345');
   });
 });


### PR DESCRIPTION
Nice work!

I noticed that you are constructing new `RegExp` instances every iteration through your `for` loop. So I moved these out of the loop.

Also, I noticed that your expressions assume that the `rel=` value is going to be wrapped in double-quotes, however the W3C seems to think it's okay to not have the double-quotes for single relations:
http://www.w3.org/wiki/LinkHeader

Lastly, I noticed you don't support multiple relation-types in the one `rel=` parameter. The RFC indicates that these should be space-delimited:
http://tools.ietf.org/html/rfc5988

```
relation-types = relation-type
                 | <"> relation-type *( 1*SP relation-type ) <">
```

I didn't bother implementing Extension Relation Types (where the relation-type provided is a URL) as that's beyond my use cases.
